### PR TITLE
Reformed criteria to become doc writer; Add new special thanks

### DIFF
--- a/support/special-thanks.md
+++ b/support/special-thanks.md
@@ -22,6 +22,7 @@ They are in charge of administrating MoonlightBot, the server, moderating conver
 ### Advanced Members
 
 - 7alisman/TonyM - HF
+- NXTCY
 
 ### Lifetime Members
 

--- a/support/volunteering.md
+++ b/support/volunteering.md
@@ -34,7 +34,7 @@ MoonlightBot translators assist in translating the commands, responses and messa
 ### Benefits
 
 - A colorful, prominent role in the server to show everyone you're one of us
-- MoonlightBot Premium (basic tier), once you have translated 50 strings
+- MoonlightBot Premium (Basic tier), once you have translated 50 strings
 - Your name on the [Special Thanks Page](./special-thanks.md#translators)
 
 ### Becoming a Translator
@@ -53,23 +53,35 @@ Your application will be looked at, and if we're satisfied that you'd make a goo
 
 ## Documentation Writer
 
-Documentation writers provide the information that users need to use MoonlightBot. They describe the bot's features and commands in detail. They create new documentation pages as new functions are added to the bot, and update existing pages to reflect changes.
+Documentation writers are the volunteers who take care of this very documentation website, and provide the information that users need to use MoonlightBot. They describe the bot's features and commands in detail, more than possibly allowed by Discord's technical limitations.
+
+They create new documentation pages as new functions are added to the bot, and update existing pages to reflect changes, to allow MoonlightBot's single developer to only focus on making the changes, which improves the productivity rate at which new features come out.
 
 ### Benefits
 
 - A colorful, prominent role in the server to show everyone you're one of us
-- MoonlightBot Premium subscription
+- The tester role (necessary to access their channels, the two roles work closely)
+- A MoonlightBot Premium subscription (Super tier)
 - Access to and testing of new features as they are developed
+- Earliest possible access to upcoming updates
 - Your name on the [Special Thanks Page](./special-thanks.md#documentation-writers)
 
 ### Becoming a Documentation Writer
 
-The documentation writer program is currently by invitation only, though we may open applications from time to time. To ensure a minimum standard of quality and fairness, we accept members who are on the [Support Server](https://discord.gg/hNQWVVC). It helps your chances of receiving an invitation from a Staff member if you follow the rules, send messages, and support MoonlightBot in other ways.
+Anyone can fork and submit pull requests to the [Documentation GitHub Repository](https://github.com/MoonlightCapital/MoonlightBot-docs/), however, we are looking for a team of maintainers who systematically expand, correct, and improve the documentation on guidance of the team, led by their caretaker.
+
+There are a handful of ways to join the official Doc Writers team and received the benefits listed above:
+
+1. **Voluntary Contributions:** If you provide helpful advice or suggest edits - whether in the server or via pull requests - the documentation caretaker (who will always be a member of our Staff) will contact you directly to invite you as a writer
+2. **Submitting an Application:** If we feel the need to expand our team, we may open applications for doc writers. When we do, we announce that in our server with instructions on how to apply. Be on the lookout for when these opportunities come up as we will likely mention `@everyone`
+
+New writers are be subject to a trial period, usually lasting two weeks, where they are asked to complete a task to determine their fitness for the program. If we're sufficiently satisfied with your performance, we will welcome you with full benefits.
 
 To be a documentation writer, you should fulfill the following requirements:
 
 - You must have a level of English comparable to B2 or higher in the [CEFR scale](<https://rm.coe.int/CoERMPublicCommonSearchServices/DisplayDCTMContent?documentId=090000168045bb52>)
+- You must be at least 16 years old
 - You must demonstrate an understanding of Markdown and GitBook formatting
-- You must have been a user of MoonlightBot (either you, or the server you represent) for at least 1 month
+- You must have been a user of MoonlightBot (based on date of first recorded interaction) for at least 1 month
 - You must demonstrate strong attention to detail and proofreading skills
 - You must not have any significative infraction history

--- a/support/volunteering.md
+++ b/support/volunteering.md
@@ -1,5 +1,9 @@
 # Volunteer Opportunities
 
+MoonlightBot is exclusively ran by volunteers - yes, even the developer - and we will be glad to accept you as part of our team! No coding skills required. In this page, you will find all the positions and tasks we are looking for.
+
+Volunteering is a nice way to show your support for our charitable activities, connect with the community, and hone your server management skills. We offer generous benefits for all our volunteers akin to those of Premium subscribers.
+
 ## Tester
 
 MoonlightBot testers act as the guardians of quality in the bot development process. They carefully examine new updates with a special copy of the bot, functioning as the voice of the end user.

--- a/support/volunteering.md
+++ b/support/volunteering.md
@@ -23,6 +23,8 @@ Their mission is to uncover bugs and annoyances that might hinder a smooth user 
 
 The tester community programme is currently by invitation only. To ensure a minimum standard of quality and fairness, we accept members who are on the [Support Server](https://discord.gg/hNQWVVC). It helps your chances of receiving an invitation from a Staff member if you follow the rules, send messages, and support MoonlightBot in other ways.
 
+{% hint style="info" %} When we send you an invitation, we have already done our due diligence in ensuring you already follow the requirements for the position. {% endhint %}
+
 ## Translator
 
 MoonlightBot translators assist in translating the commands, responses and messages shown when interacting with the bot.

--- a/support/volunteering.md
+++ b/support/volunteering.md
@@ -6,14 +6,14 @@ Volunteering is a nice way to show your support for our charitable activities, c
 
 ## Tester
 
-MoonlightBot testers act as the guardians of quality in the bot development process. They carefully examine new updates with a special copy of the bot, functioning as the voice of the end user.
+MoonlightBot testers act as the keepers of quality in the bot development process. They carefully examine new updates with a special copy of the bot, functioning as the voice of the end user.
 
 Their mission is to uncover bugs and annoyances that might hinder a smooth user experience, before they even reach the Beta release. This collaborative spirit ensures that issues are reported and then effectively addressed by the developer, making MoonlightBot not only functional but also enjoyable and user-friendly!
 
 ### Benefits
 
 - A colorful, prominent role in the server to show everyone you're one of us
-- MoonlightBot Premium subscription (duration varies based on your contributions)
+- MoonlightBot Premium subscription (Advanced tier, duration varies based on your contributions)
 - An opportunity to learn how to get the most from MoonlightBot - and many other Discord apps
 - Access to and testing of new features as they are developed
 - The ability to request small changes, work closely with the developer, and have a voice in important decisions


### PR DESCRIPTION
In this pull request I made significant changes to the description of the documentation writer position, namely:

1. It should be possible to become an official writer by making pull requests here or suggestions on Discord. You would be on the lookout for these occasional contributors and invite them as requested
2. The same, old, occasional opening of applications. You would have to establish an internal procedure on how to conduct applications, and review them as they come
3. New writers should first start with a trial period without any benefits, and give them something to do with a deadline. If they complete the trial successfully they will get the full deal. @blastoise186 can you take care of making the role and other necessary arrangements?
4. Set an age requirement to be a writer, namely 16+
5. Made the usage requirement personal, rather than server-wide. Here we actually need people with familiarity using commands directly
7. Added an intro to the page, for when it doesn't link to a section directly
8. The tester section now has an infobox stating that invites come after our due diligence. I'm honestly tired of hearing about low command usage after having already looked at their usage logs and decided to invite someone to the program. I hope this debunks this common misconception
9. Clarified the tiers of Premium each position yields

There are some miscellaneous fixes such as adding the name of a sub on the special thanks page, I'm not sure how it ended up here instead of being pushed to the testing branch.

## Checklist

* [x] Markdown formatting has been checked and renders correctly with no issue
* [x] All information provided in the pull request is accurate and up to date with MoonlightBot's functioning
* [x] All information provided is consistent with the already existing style of the rest of documentation (skip this if you're modifying the style as whole)
* [x] Reasonable efforts have been made to make the documentation readable to the end user
* [x] Reasonable effort has been put in proofreading the text for any spelling, typography or grammar errors
* [x] If this pull request features changes that have been made in beta versions, it is immediate to the end user to understand this


@blastoise186 and @sks316, I would like your analysis and some commentary on my proposal, not just a review for typos here. This is the guide you're going to use from now on and I want to make sure these are the standards you're okay with for managing personnel who takes care of the doc.