### PR TITLE
Remove zSnails from Special Thanks page

### DIFF
--- a/support/special-thanks.md
+++ b/support/special-thanks.md
@@ -46,7 +46,7 @@ They are [boosting](https://support.discord.com/hc/en-us/articles/360028038352-S
 
 ## Documentation Writers
 
-They have contributed to writing and expanding this very documentation you're reading. 
+They have contributed to writing and expanding this very documentation you're reading.
 
 {% hint type="info" %}
 This documentation is open for contributions on [GitHub](https://github.com/MoonlightCapital/MoonlightBot-docs/) or via suggestions in the [support server](https://discord.gg/hNQWVVC).
@@ -80,7 +80,7 @@ They are passionate about their native language, and know that not everyone has 
 
 * **Danish:** The-God-Of-Noise
 * **German:** Darkfinst, I_mundercover, [m]
-* **Latin American Spanish:** selffinS, v4ca, zSnails
+* **Latin American Spanish:** selffinS, v4ca
 * **French:** Michael Ngeleka, tchoupi253, Teren
 * **Hindi:** Sai Mehar
 * **Korean:** *No information available*


### PR DESCRIPTION
## Description

This pull request removes zSnails' (@zSnails here on GitHub, Discord account ID `325079232588021770` for reference) name from the translators section of the special thanks page.

The reasons for this removal are as following: subject's last translation was on September 1, 2024 and has been subsequently avoidant towards my efforts to show him one of his es-419 peers misbehaving **and me reprimanding him** for that. Last DM from him was on June 20, 2025 and then he started ignoring me. He was consequently contacted for the September 2025 purge where he still ignored me and got his visibility suspended from the program, and then I blocked him with a parting shot during a friend list purge on November 24, 2025 to make it certain he wouldn't reply at a random point in time.

<img width="1695" height="1045" alt="Screenshot showing last conversation where the subject replied and surroundings" src="https://github.com/user-attachments/assets/018e5840-dcb4-49c0-9fee-781d04f06771" />

The last straw was him leaving Moonlight Labs earlier this month, days after I posted the Volunteer of the Month announcement where we (voted on a poll and then) gave the award to a former volunteer for the outstandingly good and praiseworthy act of... [resigning according to the proper procedure](https://moonlightbot.gitbook.io/docs/policies/volunteer-code-of-conduct#id-4-inactivity-break-notices-resigning-from-a-volunteer-position). I guess the subject I'm removing got envious about it and rage-quit altogether.

All in all being ignored for so long, not only by him, has caused me to suffer significant emotional distress and led to mistrust, generated pointless workloads, and created delays. Having a dedicated Staff member available for relationship concerns with volunteer would help, but with all the vacancies and unavailability it all sums up to the point where the situation gets hard to manage and results in a loss of focus.

And yes, I'm well aware this is a publicly readable message and that's the entire point of it- The new Volunteer Code of Conduct makes it explicit we can enforce it with "Removal of name/credit from the [Special Thanks Page](https://moonlightbot.gitbook.io/docs/support-our-work/special-thanks)", even though there's established precedent of us doing it before (#66 #57 #47 #50 _oh the irony on these last two_ https://github.com/MoonlightCapital/MoonlightBot-docs/commit/86bcfb52c3a06c33ba7985ea39ed3f44fc60fe9c https://github.com/MoonlightCapital/MoonlightBot-docs/commit/fa581568f5b9a3ad3c4e50b45944ea603082fb42 https://github.com/MoonlightCapital/MoonlightBot-docs/commit/408de5be4b3fa1f9e29e08d5195f9dcc7bd64c21) because it was still a valid enforcement mean, and I want to send another very CLEAR signal that following procedures pays off, ESPECIALLY with how simple and privacy-friendly I made it to resign from a volunteer program and not lose much on it, from my subjective experience I haven't felt anything negative against those who followed it, and a simple quick message does make a difference including on a logistical standpoint. I just don't tolerate how certain people have helped for a bit and seemingly used that to break the rules expecting leniency or to go unnoticed, _just because they used to be helpful_. So why am I making it public and putting all this effort in writing this? To have a future reference to start from in case it happens again. And I hope this will make people think twice before offering to help us then go their way and act disruptively towards the volunteers that are effectively performing well, other than keeping rewards they earned if they resign and don't act on our patience to then get kicked out.

I've known zSnails for a long time, much longer than he's been in Moonlight Labs, and so seemingly does @blastoise186 by having him on mutual friends on Discord. I truly don't understand why he pulled this 180 after bringing it up himself, because he brought it up himself in a meme conversation. All he had to do was send me a message! I always try to assume good faith and solve situations of conflict by just having a chat about it, sometimes I need a safe space and some witnesses to prevent tense situations from degenerating, but if the other party doesn't cooperate, _rien ne va plus_.

<img width="972" height="1462" alt="paveikslas" src="https://github.com/user-attachments/assets/c7123312-75d6-438b-8cee-3d7684c9862c" />

Thanks for reading and I hope similar PR won't be necessary in the future.

## Checklist

* [x] Markdown formatting has been checked and renders correctly with no issue
* [x] All information provided in the pull request is accurate and up to date with MoonlightBot's functioning
* [x] All information provided is consistent with the already existing style of the rest of documentation (skip this if you're modifying the style as whole)
* [x] Reasonable efforts have been made to make the documentation readable to the end user
* [x] Reasonable effort has been put in proofreading the text for any spelling, typography or grammar errors
* [x] If this pull request features changes that have been made in beta versions, it is immediate to the end user to understand this
