### PR TITLE
Remove another deviant unbooster

### DIFF
--- a/support/special-thanks.md
+++ b/support/special-thanks.md
@@ -42,7 +42,6 @@ They are [boosting](https://support.discord.com/hc/en-us/articles/360028038352-S
 * Irisplooshi
 * Kalosianlitten
 * Miky88
-* Raulix64 - Connections ⚡️
 
 ## Documentation Writers
 


### PR DESCRIPTION
## Description
Simple enforcement of [section 6 of the Acceptable Use Policy](https://moonlightbot.gitbook.io/docs/policies/acceptable-use-policy#id-6-resource-provider-donation-policy) to remove another former booster who escalated things too far, got banned a week ago and didn't appeal by then.

For anyone reading this: removing boosts isn't against the policy (in fact this guy's boost was removed in January, and the cause was quickly confirmed to be a completely natural Nitro subscription expiration), but taking things farther and becoming disruptive instead of showing an understanding of the overall situation is a no-no.

## Checklist

* [x] Markdown formatting has been checked and renders correctly with no issue
* [x] All information provided in the pull request is accurate and up to date with MoonlightBot's functioning
* [x] All information provided is consistent with the already existing style of the rest of documentation (skip this if you're modifying the style as whole)
* [x] Reasonable efforts have been made to make the documentation readable to the end user
* [x] Reasonable effort has been put in proofreading the text for any spelling, typography or grammar errors
* [x] If this pull request features changes that have been made in beta versions, it is immediate to the end user to understand this
